### PR TITLE
build: accept tags with undescore

### DIFF
--- a/build
+++ b/build
@@ -107,7 +107,7 @@ for PKG_PATH in $(catkin_topological_order --only-folders || colcon list --topol
 
   # Set the version based on the checked out tag that contain at least on digit
   # strip any leading non digits as they are not part of the version number
-  sed -i "1 s@([^)]*)@($( (git describe --tag  --match "*[0-9]*" 2>/dev/null || echo 0) | sed 's@^[^0-9]*@@')-$(date +%Y.%m.%d.%H.%M))@" debian/changelog
+  sed -i "1 s@([^)]*)@($( (git describe --tag  --match "*[0-9]*" 2>/dev/null | sed "s/_/~/" || echo 0) | sed 's@^[^0-9]*@@')-$(date +%Y.%m.%d.%H.%M))@" debian/changelog
 
   # https://github.com/ros-infrastructure/bloom/pull/643
   echo 11 > debian/compat


### PR DESCRIPTION
Some projects, as the piglit, translate versions as

```
0~git20230531-5036601c4-1
```

into git tags
```
debian/0_git20230531-5036601c4-1
```
When reading git tag, convert back from illegal character '_' back to `~`